### PR TITLE
Fix memory leak

### DIFF
--- a/Code/miniVideoPlayer/miniVideoPlayer.ino
+++ b/Code/miniVideoPlayer/miniVideoPlayer.ino
@@ -292,6 +292,10 @@ void playVideo(String videoFilename, String audioFilename)
         vFile.close();
         aFile -> close();
     }
+    if (mjpeg_buf)
+    {
+        free(mjpeg_buffer);
+    }
 }
 
 // pixel drawing callback

--- a/Code/miniVideoPlayer/miniVideoPlayer.ino
+++ b/Code/miniVideoPlayer/miniVideoPlayer.ino
@@ -294,7 +294,7 @@ void playVideo(String videoFilename, String audioFilename)
     }
     if (mjpeg_buf)
     {
-        free(mjpeg_buffer);
+        free(mjpeg_buf);
     }
 }
 


### PR DESCRIPTION
At the start of `playVideo()`, a buffer of MJPEG_BUFFER_SIZE bytes is allocated with malloc, never to be freed. When the next video plays another buffer is created, then another and another, etc. This pull request frees the buffer at the end of the function (if allocation was successful).