### PR TITLE
Fix exception, fix hangup at video end, much code cleanup

### DIFF
--- a/Code/miniVideoPlayer/MjpegClass.h
+++ b/Code/miniVideoPlayer/MjpegClass.h
@@ -76,6 +76,9 @@ public:
     _pfnDraw = pfnDraw;
     _enableMultiTask = enableMultiTask;
     _useBigEndian = useBigEndian;
+    _mjpeg_buf_offset = 0;
+    _inputindex = 0;
+    _remain = 0;
 
     if (!_read_buf)
     {

--- a/Code/miniVideoPlayer/miniVideoPlayer.ino
+++ b/Code/miniVideoPlayer/miniVideoPlayer.ino
@@ -28,20 +28,19 @@ int BTN_NEXT = 21;
 int BTN_PREV = 15;
  
 /* Arduino_GFX */
-/* NOTE - IF RED AND BLUE COLORS ARE SWAPPED, MODIFY "Arduino_ST7735.h" in "\Arduino\libraries\GFX_Library_for_Arduino\src\display" BY FLIPPING bool bgr. */
 #include <Arduino_GFX_Library.h>
 Arduino_ESP32SPI *bus = new Arduino_ESP32SPI(LCD_DC_A0 /* DC */, LCD_CS /* CS */, LCD_SCK /* SCK */, LCD_MOSI /* MOSI */, LCD_MISO /* MISO */);
-Arduino_GFX *gfx = new Arduino_ST7735(bus, LCD_RESET /* RST */, 3 /* rotation */, false /* IPS */);
+/* NOTE - IF RED AND BLUE COLORS ARE SWAPPED, FLIP bool bgr in below constructor. */
+Arduino_GFX *gfx = new Arduino_ST7735(bus, LCD_RESET /* RST */, 3 /* rotation */, false /* IPS */, ST7735_TFTWIDTH /* w*/, ST7735_TFTHEIGHT /* h*/,
+                                      0 /* col_offset1 */, 0 /* row_offset1 */, 0 /* col_offset2 */, 0 /* row_offset2 */, true /* bgr */);
 
 /* MP3 Audio */
 #include <AudioFileSourceFS.h>
-#include <AudioFileSourceID3.h>
-#include <AudioFileSourceSD.h> 
 #include <AudioGeneratorMP3.h>
 #include <AudioOutputI2S.h>
-static AudioGeneratorMP3 *mp3;
-static AudioFileSourceFS *aFile;
-static AudioOutputI2S *out;
+static AudioGeneratorMP3 *mp3 = NULL;
+static AudioFileSourceFS *aFile = NULL;
+static AudioOutputI2S *out = NULL;
 
 /* MJPEG Video */
 #include "MjpegClass.h"
@@ -106,7 +105,12 @@ void setup()
 
   attachInterrupt(BTN_NEXT, incrFileNo, RISING);
   attachInterrupt(BTN_PREV, decrFileNo, RISING);
-
+ 
+  // Init audio
+  out = new AudioOutputI2S(0,1,128);
+  mp3 = new AudioGeneratorMP3();
+  aFile = new AudioFileSourceFS(SD);
+ 
   // Init Video
   gfx->begin();
   gfx->fillScreen(BLACK);
@@ -120,7 +124,7 @@ void setup()
   else
   {
     root = SD.open("/");
-    noFiles = getNoFiles(root,0);
+    noFiles = getNoFiles(root);
     Serial.print("Found ");
     Serial.print(noFiles);
     Serial.println(" in root directory!");
@@ -129,7 +133,7 @@ void setup()
 
 }
 
-int getNoFiles(File dir, int numTabs)
+int getNoFiles(File dir)
 {  
   while (true)
   {
@@ -138,11 +142,6 @@ int getNoFiles(File dir, int numTabs)
     {
       // no more files
       break;
-    }
-    
-    for (uint8_t i = 0; i < numTabs; i++)
-    {
-      Serial.print('\t');
     }
     
     if (entry.isDirectory()) 
@@ -154,7 +153,7 @@ int getNoFiles(File dir, int numTabs)
     {
       Serial.println(entry.name());
       entry.close();
-      noFiles = noFiles+1;
+      ++noFiles;
     }
   }
   return noFiles;
@@ -185,17 +184,16 @@ void getFilenames(File dir, int fileNo)
       {
         entry.close(); //Close current video file
         entry =  dir.openNextFile(); //Open and close corresponding audio file
-        audioFilename = entry.name();
         entry.close();
         fileCounter = fileCounter+1;
         entry = dir.openNextFile(); // Open next file for reading
       }
-      videoFilename = entry.name();
+      videoFilename = entry.path();
       Serial.print("Loading video: ");
       Serial.println(videoFilename);
       entry.close();
       entry =  dir.openNextFile();
-      audioFilename = entry.name();
+      audioFilename = entry.path();
       Serial.print("Loading audio: ");
       Serial.println(audioFilename);
       entry.close();
@@ -206,116 +204,98 @@ void getFilenames(File dir, int fileNo)
 
 void playVideo(String videoFilename, String audioFilename)
 {
-    int next_frame = 0;
-    int skipped_frames = 0;  
-    unsigned long total_play_audio = 0;
-    unsigned long total_read_video = 0;
-    unsigned long total_decode_video = 0;
-    unsigned long start_ms, curr_ms, next_frame_ms;
+  int next_frame = 0;
+  int skipped_frames = 0;  
+  unsigned long total_play_audio = 0;
+  unsigned long total_read_video = 0;
+  unsigned long total_decode_video = 0;
+  unsigned long start_ms, curr_ms, next_frame_ms;
 
-    int brightPWM = 0;
+  int brightPWM = 0;
     
-    Serial.println("In playVideo() loop!");
-    /*
-    out = new AudioOutputI2S(0,1,128);
-    mp3 = new AudioGeneratorMP3();
-    aFile = new AudioFileSourceFS(SD, audioFilename.c_str()); //Typecast audioFilename String for AudioFileSourceFS input
-    */
+  Serial.println("In playVideo() loop!");
 
-    if (!out)
-      out = new AudioOutputI2S(0,1,128);
-    if (!mp3)
-      mp3 = new AudioGeneratorMP3();
-    if (aFile)
-      delete aFile;
-    aFile = new AudioFileSourceFS(SD, audioFilename.c_str()); //Typecast audioFilename String for AudioFileSourceFS input
+  if (mp3 && mp3->isRunning())
+    mp3->stop();
+  if (!aFile->open(audioFilename.c_str()))
+    Serial.println(F("Failed to open audio file"));   
+  Serial.println("Created aFile!");
+ 
+  File vFile = SD.open(videoFilename);
+  Serial.println("Created vFile!");
+
+  uint8_t *mjpeg_buf = (uint8_t *)malloc(MJPEG_BUFFER_SIZE);
+  if (!mjpeg_buf)
+  {
+    Serial.println(F("mjpeg_buf malloc failed!"));
+  }
+  else
+  {
+    // init Video
+    mjpeg.setup(&vFile, mjpeg_buf, drawMCU, false, true); //MJPEG SETUP -> bool setup(Stream *input, uint8_t *mjpeg_buf, JPEG_DRAW_CALLBACK *pfnDraw, bool enableMultiTask, bool useBigEndian)
+  }
     
-    Serial.println("Created aFile!");
-    File vFile = SD.open(videoFilename);
-    Serial.println("Created vFile!");
-
-    uint8_t *mjpeg_buf = (uint8_t *)malloc(MJPEG_BUFFER_SIZE);
-    if (!mjpeg_buf)
-    {
-      Serial.println(F("mjpeg_buf malloc failed!"));
-      
-    }
-    else
-    {
-      // init Video
-      mjpeg.setup(&vFile, mjpeg_buf, drawMCU, false, true); //MJPEG SETUP -> bool setup(Stream *input, uint8_t *mjpeg_buf, JPEG_DRAW_CALLBACK *pfnDraw, bool enableMultiTask, bool useBigEndian)
-    }
-    
-    if (!vFile || vFile.isDirectory()) 
-    {
-      Serial.println(("ERROR: Failed to open "+ videoFilename +".mjpeg file for reading"));
-      gfx->println(("ERROR: Failed to open "+ videoFilename +".mjpeg file for reading"));
-    }
-    else
-    {
-      // init audio
-      mp3->begin(aFile, out);
-      start_ms = millis();
-      curr_ms = start_ms;
-      next_frame_ms = start_ms + (++next_frame * 1000 / FPS);
-
-      int threshold = vFile.available()*0.01; // Skip to next file 1% from the end
-      
-        //while (vFile.available() && buttonPressed == false)
-        while (vFile.available()>threshold && buttonPressed == false)
-        {
-          Serial.print("Threshold: ");
-          Serial.print(threshold);
-          Serial.print(" | vFile has: ");
-          Serial.print(vFile.available());
-          Serial.println(" bytes left.");
-          
-          // Read video
-          mjpeg.readMjpegBuf();
-          total_read_video += millis() - curr_ms;
-          curr_ms = millis();
-
-          if (millis() < next_frame_ms) // check show frame or skip frame
-          {
-            // Play video
-            mjpeg.drawJpg();
-            total_decode_video += millis() - curr_ms;
-          }
-          else
-          {
-            ++skipped_frames;
-            Serial.println(F("Skip frame"));
-          }
-          curr_ms = millis();
-          // Play audio
-          if ((mp3->isRunning()) && (!mp3->loop()))
-          {
-            mp3->stop();
-          }
+  if (!vFile || vFile.isDirectory()) 
+  {
+    Serial.println(("ERROR: Failed to open "+ videoFilename +".mjpeg file for reading"));
+    gfx->println(("ERROR: Failed to open "+ videoFilename +".mjpeg file for reading"));
+  }
+  else
+  {
+    // init audio
+    if (!mp3->begin(aFile, out)
+      Serial.println(F("Failed to start audio!"));
+    start_ms = millis();
+    curr_ms = start_ms;
+    next_frame_ms = start_ms + (++next_frame * 1000 / FPS);
   
-          total_play_audio += millis() - curr_ms;
-          while (millis() < next_frame_ms)
-          {
-            vTaskDelay(1);
-          }
-          curr_ms = millis();
-          next_frame_ms = start_ms + (++next_frame * 1000 / FPS);
-        }
-        if (fullPlaythrough == false)
-        {
-          mp3->stop();
-        }
-        buttonPressed = false; // reset buttonPressed boolean
-        int time_used = millis() - start_ms;
-        int total_frames = next_frame - 1;
-        Serial.println(F("MP3 audio MJPEG video end"));
-        vFile.close();
-        aFile -> close();
-    }
-    if (mjpeg_buf)
+    while (vFile.available() && buttonPressed == false)
     {
-        free(mjpeg_buf);
+      // Read video
+      mjpeg.readMjpegBuf();
+      total_read_video += millis() - curr_ms;
+      curr_ms = millis();
+      if (millis() < next_frame_ms) // check show frame or skip frame
+      {
+        // Play video
+        mjpeg.drawJpg();
+        total_decode_video += millis() - curr_ms;
+      }
+      else
+      {
+        ++skipped_frames;
+        Serial.println(F("Skip frame"));
+      }
+      curr_ms = millis();
+      // Play audio
+      if (mp3->isRunning() && !mp3->loop())
+      {
+        mp3->stop();
+      }
+
+      total_play_audio += millis() - curr_ms;
+      while (millis() < next_frame_ms)
+      {
+        vTaskDelay(1);
+      }
+      curr_ms = millis();
+      next_frame_ms = start_ms + (++next_frame * 1000 / FPS);
     }
+    if (fullPlaythrough == false)
+    {
+      mp3->stop();
+    }
+    buttonPressed = false; // reset buttonPressed boolean
+    int time_used = millis() - start_ms;
+    int total_frames = next_frame - 1;
+    Serial.println(F("MP3 audio MJPEG video end"));
+    vFile.close();
+    aFile -> close();
+  }
+  if (mjpeg_buf)
+  {
+    free(mjpeg_buf);
+  }
 }
 
 // pixel drawing callback

--- a/Code/miniVideoPlayer/miniVideoPlayer.ino
+++ b/Code/miniVideoPlayer/miniVideoPlayer.ino
@@ -26,7 +26,7 @@ int LCD_CS = 5;
 
 int BTN_NEXT = 21;
 int BTN_PREV = 15;
- 
+
 /* Arduino_GFX */
 #include <Arduino_GFX_Library.h>
 Arduino_ESP32SPI *bus = new Arduino_ESP32SPI(LCD_DC_A0 /* DC */, LCD_CS /* CS */, LCD_SCK /* SCK */, LCD_MOSI /* MOSI */, LCD_MISO /* MISO */);
@@ -105,12 +105,12 @@ void setup()
 
   attachInterrupt(BTN_NEXT, incrFileNo, RISING);
   attachInterrupt(BTN_PREV, decrFileNo, RISING);
- 
+
   // Init audio
   out = new AudioOutputI2S(0,1,128);
   mp3 = new AudioGeneratorMP3();
   aFile = new AudioFileSourceFS(SD);
- 
+
   // Init Video
   gfx->begin();
   gfx->fillScreen(BLACK);
@@ -134,7 +134,7 @@ void setup()
 }
 
 int getNoFiles(File dir)
-{  
+{
   while (true)
   {
     File entry =  dir.openNextFile();
@@ -143,12 +143,12 @@ int getNoFiles(File dir)
       // no more files
       break;
     }
-    
-    if (entry.isDirectory()) 
+
+    if (entry.isDirectory())
     {
       // Skip file if in subfolder
        entry.close(); // Close folder entry
-    } 
+    }
     else
     {
       Serial.println(entry.name());
@@ -160,8 +160,8 @@ int getNoFiles(File dir)
 }
 
 void getFilenames(File dir, int fileNo)
-{ 
-  int fileCounter = 1; 
+{
+  int fileCounter = 1;
   while (true)
   {
     File entry =  dir.openNextFile();
@@ -170,14 +170,14 @@ void getFilenames(File dir, int fileNo)
       // no more files
       break;
     }
-        
+
     Serial.println(entry.name());
-    
-    if (entry.isDirectory()) 
+
+    if (entry.isDirectory())
     {
       // Skip file if in subfolder
        entry.close(); // Close folder entry
-    } 
+    }
     else // Get filename
     {
       while (fileCounter<fileNo) // While not at correct file pair number
@@ -205,14 +205,14 @@ void getFilenames(File dir, int fileNo)
 void playVideo(String videoFilename, String audioFilename)
 {
   int next_frame = 0;
-  int skipped_frames = 0;  
+  int skipped_frames = 0;
   unsigned long total_play_audio = 0;
   unsigned long total_read_video = 0;
   unsigned long total_decode_video = 0;
   unsigned long start_ms, curr_ms, next_frame_ms;
 
   int brightPWM = 0;
-    
+
   Serial.println("In playVideo() loop!");
 
   if (mp3 && mp3->isRunning())
@@ -220,7 +220,7 @@ void playVideo(String videoFilename, String audioFilename)
   if (!aFile->open(audioFilename.c_str()))
     Serial.println(F("Failed to open audio file"));   
   Serial.println("Created aFile!");
- 
+
   File vFile = SD.open(videoFilename);
   Serial.println("Created vFile!");
 
@@ -234,8 +234,8 @@ void playVideo(String videoFilename, String audioFilename)
     // init Video
     mjpeg.setup(&vFile, mjpeg_buf, drawMCU, false, true); //MJPEG SETUP -> bool setup(Stream *input, uint8_t *mjpeg_buf, JPEG_DRAW_CALLBACK *pfnDraw, bool enableMultiTask, bool useBigEndian)
   }
-    
-  if (!vFile || vFile.isDirectory()) 
+
+  if (!vFile || vFile.isDirectory())
   {
     Serial.println(("ERROR: Failed to open "+ videoFilename +".mjpeg file for reading"));
     gfx->println(("ERROR: Failed to open "+ videoFilename +".mjpeg file for reading"));
@@ -243,12 +243,12 @@ void playVideo(String videoFilename, String audioFilename)
   else
   {
     // init audio
-    if (!mp3->begin(aFile, out)
+    if (!mp3->begin(aFile, out))
       Serial.println(F("Failed to start audio!"));
     start_ms = millis();
     curr_ms = start_ms;
     next_frame_ms = start_ms + (++next_frame * 1000 / FPS);
-  
+
     while (vFile.available() && buttonPressed == false)
     {
       // Read video

--- a/Code/miniVideoPlayer/miniVideoPlayer.ino
+++ b/Code/miniVideoPlayer/miniVideoPlayer.ino
@@ -188,12 +188,23 @@ void getFilenames(File dir, int fileNo)
         fileCounter = fileCounter+1;
         entry = dir.openNextFile(); // Open next file for reading
       }
+  
+  // arduino-esp32 < 2.0.0 were based on IDF 3.3.5 (and earlier).
+  //               >= 2.0.0 on IDF 4.4 (and later) -> this version includes File::path()
+  #if ESP_IDF_VERSION_MAJOR > 4 || (ESP_IDF_VERSION_MAJOR == 4 && ESP_IDF_VERSION_MINOR >= 4)
       videoFilename = entry.path();
+  #else
+      videoFilename = entry.name();
+  #endif
       Serial.print("Loading video: ");
       Serial.println(videoFilename);
       entry.close();
       entry =  dir.openNextFile();
+  #if ESP_IDF_VERSION_MAJOR > 4 || (ESP_IDF_VERSION_MAJOR == 4 && ESP_IDF_VERSION_MINOR >= 4)
       audioFilename = entry.path();
+  #else
+      audioFilename = entry.name();
+  #endif
       Serial.print("Loading audio: ");
       Serial.println(audioFilename);
       entry.close();


### PR DESCRIPTION
Ok, this is a big PR, but mostly because I couldn't stand the inconsistent indentation :) And I don't feel like splitting this up in 3 or 4 separate PR's (honestly I wouldn't even know how).

1. It cleans up my own memory leak fix. In this type of program, with a `setup()` and a `loop()`, the things that need to be set once should of course go in the setup, I don't know what I was thinking. This moves creation of the `mp3`, `out` and `aFile` objects to the setup and only calls `aFile::open()` in the player loop when a new file needs to be opened.

   This is really just a clean up, the current method also fixes the leak. The exception you encountered has a different reason. When you suspect a memory leak, adding 
```
  Serial.print(F("Start of loop! Available memory: "));
  Serial.print(esp_get_free_heap_size());
  Serial.println(F(" bytes"));
```
   
   will help. I have done that with this code, and the amount of free memory is stable while looping through a bunch of files.

2. I tried running the full code (without my modifications) to see if I also got the exception you encountered (mentioned here: https://github.com/SuperMakeSomething/mini-video-player/issues/2#issuecomment-1252934705). I _think_ I did (although I can not be 100% sure it's the same problem). This was caused by the mp3 not properly being stopped before starting a new one. I think I fixed this by adding
```
  if (mp3 && mp3->isRunning())
    mp3->stop();
```
   at the start of the player loop. After this I did not encounter any more exceptions.

3. I also experienced the video hanging at the end. Though I saw this behavior every time, since the first code was posted here, so I'm not sure why it worked for you before. This is because the `MjpegClass` was not made to be reused for multiple video's. Some of the values set in it's setup need to be reset when a new file is played. For this reason, this PR adds
```
    _mjpeg_buf_offset = 0;
    _inputindex = 0;
    _remain = 0;
```
   to the MjpegClass. For me, this fixes the hang without the need to stop playback before the file is fully read (this PR also removes the `threshold` code).

4. Removed some unneeded `#include`'s
5. Cleaned up `getNoFiles()` (which seemed to be copy-pasted from arduino's example code without being modified for its new purpose). Also, in my program it always failed to open the files when I set the filenames using `entry.name()`, so this PR changes that to `entry.path()`. Not sure why it would work for you though, so maybe something else is wrong.
6. Changed `Arduino_ST7735` creation and comment to not encourage people to unnecessarily change system wide library files.
7. I think the rest is just changes in whitespace (much needed ;) ).

***NOTE*** I have tested this code, and it seems to work for me. I have no memory leaks, no uncaught exceptions, and no video hanging. But, I do not own any audio hardware, nothing is actually connected on my board for that. So please test this code thoroughly before merging.

Sorry for the big messy PR, I hope it helps you, but feel free to not merge it or pick and choose your changes.